### PR TITLE
Update RDCWindow.cs

### DIFF
--- a/RDCWindow.cs
+++ b/RDCWindow.cs
@@ -389,7 +389,20 @@ namespace EasyConnect
 
         private void _closeButton_Click(object sender, EventArgs e)
         {
+          if (AllowClose())
+          {
             Close();
+          }
+          else
+          {
+            Application.Exit();
+          }
+        }
+        
+        private bool AllowClose()
+        {
+          //todo: check if this is the last tab, if yes return false, and instead of close tab, exit application
+          return true;
         }
 
         private void _exitMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
if this is the last tab, we should exit (or ask for exit) instead of closing it, because closing it threw designer error.
